### PR TITLE
fix: makes mcp an executable via github with npx command

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ Configure your MCP servers JSON file for your designated consuming environment b
         "github:mrkooblu/semrush-mcp"
       ],
       "env": {
-        "SEMRUSH_API_KEY": "your-api-key"
+        "SEMRUSH_API_KEY": "your-api-key",
+        "LOG_LEVEL": "info"
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -118,9 +118,34 @@ To add this MCP server to Cursor or Claude:
      - Other optional variables as needed
 4. Click "Save"
 
-### Claude Desktop
+## Usage Using NPX
 
-Configure the MCP server in the Claude Desktop settings following the documentation.
+### Using Environment Variables in Cursor/Claude/Windsurf Configuration
+
+Configure your MCP servers JSON file for your designated consuming environment by adding this MCP using the following format:
+
+```json
+{
+  "mcpServers": {
+    "semrush-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "github:mrkooblu/semrush-mcp"
+      ],
+      "env": {
+        "SEMRUSH_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+Running it from your terminal:
+
+```bash
+SEMRUSH_API_KEY=your-api-key npx -y github:mrkooblu/semrush-mcp
+```
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,9 @@
         "node-cache": "^5.1.2",
         "zod": "^3.24.1"
       },
+      "bin": {
+        "semrush-mcp": "dist/index.js"
+      },
       "devDependencies": {
         "@types/node": "^22",
         "shx": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "An MCP server for Semrush API integration",
   "main": "dist/index.js",
   "type": "module",
-  "bin": {
-    "semrush-mcp": "./dist/index.js"
-  },
+  "bin": "./dist/index.js",
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "npm run build",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
   "description": "An MCP server for Semrush API integration",
   "main": "dist/index.js",
   "type": "module",
+  "bin": "./dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && shx chmod +x dist/*.js",
+    "prepare": "npm run build",
     "start": "node dist/index.js",
-    "dev": "ts-node src/index.ts"
+    "dev": "tsx src/index.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "An MCP server for Semrush API integration",
   "main": "dist/index.js",
   "type": "module",
-  "bin": "./dist/index.js",
+  "bin": {
+    "semrush-mcp": "./dist/index.js"
+  },
   "scripts": {
     "build": "tsc && shx chmod +x dist/*.js",
     "prepare": "npm run build",

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,9 +57,19 @@ export const logger: Logger = {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ENV_FILE_PATH: string = resolve(__dirname, '..', '.env');
+let secretLoaded: boolean = false;
 
 // Load environment variables
 const loadEnv = (): void => {
+  if (secretLoaded) return;
+
+  // Check external environment first
+  const externalKey: string | undefined = process.env.SEMRUSH_API_KEY;
+  if (externalKey) {
+    logger.info('Using SEMRUSH_API_KEY from external environment variables.');
+    secretLoaded = true;
+    return;
+  }
   try {
     const envContent: string = readFileSync(ENV_FILE_PATH, 'utf8');
     const envVars: Record<string, string> = envContent.split('\n').reduce((acc, line) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
-import { config, logger, logConfigStatus } from './config.js';
+#!/usr/bin/env node
+
+import { logger, logConfigStatus } from './config.js';
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {


### PR DESCRIPTION
# Summary

- This improvement allows users to simply leverage the npx executable option when adding to their consuming client of choice

## Changes

- Mods to package.json to correct build script & addition of explicit `bin` location
- shebang line added to main mcp file
- Additions to README to guide users how to utilize this method to install into their environment:

```json
{
  "mcpServers": {
    "semrush-mcp": {
      "command": "npx",
      "args": [
        "-y",
        "github:mrkooblu/semrush-mcp"
      ],
      "env": {
        "SEMRUSH_API_KEY": "your-api-key",
        "LOG_LEVEL": "info"
      }
    }
  }
}
```